### PR TITLE
Add environment variable to supply pkpass key password

### DIFF
--- a/vdv_pkpass/settings.py
+++ b/vdv_pkpass/settings.py
@@ -123,6 +123,8 @@ AWS_S3_SECRET_ACCESS_KEY = os.getenv("S3_SECRET_ACCESS_KEY", "")
 AWS_S3_ADDRESSING_STYLE = "virtual"
 AWS_S3_SIGNATURE_VERSION = "s3v4"
 
+PKPASS_KEY_PASSWORD = os.getenv("PKPASS_KEY_PASSWORD", None)
+
 STORAGES = {
     "default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"},
     "staticfiles": {"BACKEND": "storages.backends.s3boto3.S3ManifestStaticStorage"},
@@ -145,7 +147,7 @@ with open(os.getenv("WWDR_CERTIFICATE_LOCATION"), "rb") as f:
 with open(os.getenv("PKPASS_CERTIFICATE_LOCATION"), "rb") as f:
     PKPASS_CERTIFICATE = cryptography.x509.load_der_x509_certificate(f.read())
 with open(os.getenv("PKPASS_KEY_LOCATION"), "rb") as f:
-    PKPASS_KEY = cryptography.hazmat.primitives.serialization.load_pem_private_key(f.read(), None)
+    PKPASS_KEY = cryptography.hazmat.primitives.serialization.load_pem_private_key(f.read(), PKPASS_KEY_PASSWORD.encode("ASCII") if PKPASS_KEY_PASSWORD else None)
 
 PKPASS_CONF = {
     "organization_name": os.getenv("PKPASS_ORGANIZATION_NAME"),

--- a/vdv_pkpass/settings_dev.py
+++ b/vdv_pkpass/settings_dev.py
@@ -137,8 +137,14 @@ with open(BASE_DIR / "priv" / "wwdrg4.crt", "rb") as f:
     WWDR_CERTIFICATE = cryptography.x509.load_der_x509_certificate(f.read())
 with open(BASE_DIR / "priv" / "pass.crt", "rb") as f:
     PKPASS_CERTIFICATE = cryptography.x509.load_der_x509_certificate(f.read())
+PKPASS_KEY_PASSWORD = None
+try:
+    with open(BASE_DIR / "priv" / "pass.key_pw", "rb") as f:
+        PKPASS_KEY_PASSWORD = f.read()
+except FileNotFoundError:
+    pass
 with open(BASE_DIR / "priv" / "pass.key", "rb") as f:
-    PKPASS_KEY = cryptography.hazmat.primitives.serialization.load_pem_private_key(f.read(), None)
+    PKPASS_KEY = cryptography.hazmat.primitives.serialization.load_pem_private_key(f.read(), PKPASS_KEY_PASSWORD)
 
 PKPASS_CONF = {
     "organization_name": "Q Misell",


### PR DESCRIPTION
My signing key has a password attached to it. Because there is currently no provision for this, this PR adds a environment variable that may optionally be supplied called `PKPASS_KEY_PASSWORD`. 

If this isn't provided, the `password` argument passed to `cryptography.hazmat.primitives.serialization.load_pem_private_key` at vdv_pkpass/settings.py#L150 will be `None` as is currently the case.