### PR TITLE
allow scanspeed to be modified w/ str enums

### DIFF
--- a/main/aztec.py
+++ b/main/aztec.py
@@ -7,7 +7,7 @@ class AztecError(Exception):
     pass
 
 
-def decode(img_data: bytes):
+def decode(img_data: bytes, *, scan_speed: str = "slow"):
     try:
         import Barkoder
     except ImportError as e:
@@ -18,7 +18,17 @@ def decode(img_data: bytes):
     config = cfg_response.get_config()
 
     config.encodingCharacterSet = "BINARY"
-    config.decodingSpeed = Barkoder.DecodingSpeed.Slow
+
+    match scan_speed.lower():
+        case "slow":
+            config.decodingSpeed = Barkoder.DecodingSpeed.Slow
+        case "normal":
+            config.decodingSpeed = Barkoder.DecodingSpeed.Normal
+        case "fast":
+            config.decodingSpeed = Barkoder.DecodingSpeed.Fast
+        case _:
+            config.decodingSpeed = Barkoder.DecodingSpeed.Slow
+
     assert config.set_enabled_decoders([
         Barkoder.DecoderType.Aztec,
         Barkoder.DecoderType.AztecCompact,

--- a/main/views/api.py
+++ b/main/views/api.py
@@ -62,8 +62,15 @@ def upload_aztec_img(request):
             "message": "The photo must be a JPEG or PNG"
         }), status=422, content_type="application/json")
 
+    scan_speed = request.POST.get("scan_speed", "slow")
+    if scan_speed not in [ "slow", "normal", "fast" ]:
+        return HttpResponse(json.dumps({
+            "title": "Bad setting",
+            "message": "Scan speed can only be one of 'slow', 'normal' or 'fast'"
+        }), status=400, content_type="application/json")
+
     try:
-        barcode_data = aztec.decode(file.read())
+        barcode_data = aztec.decode(file.read(), scan_speed=scan_speed)
     except aztec.AztecError as e:
         return HttpResponse(json.dumps({
             "title": "Unable to decode",


### PR DESCRIPTION
(can a fellow fren test this for me, i don't have a proper venv set up yet)

this pr adds a `scan_speed` named variable to the aztec decode function; that enumerates the scanning speed for the barkoder library and also exposes the option to the `upload_aztec_img` api (~~intentionally~~ not documented yet).