### PR TITLE
Fix for ÖBB PDFs and some other things

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,5 +11,6 @@
 /yarn.lock
 /.gitignore
 /kube
+/barkoder/build
 tickeos.py
 parsed_licenses.lcs

--- a/README.md
+++ b/README.md
@@ -52,14 +52,20 @@ cd barkoder/build
 # Build
 cmake .. && make
 
-# Copy to site-packages
+# Copy to site-packages (run in activated virtualenv)
 cd ../..
-cp ./barkoder/build/Barkoder.cpython-313-x86_64-linux-gnu.so ./env_vdv_pkpass/lib/python3.13/site-packages/
+cp ./barkoder/build/Barkoder.cpython-313-x86_64-linux-gnu.so "$(python -c 'import site; print(site.getsitepackages()[0])')"
 ```
 
 ### Other changes
 
-In `./manage.py:9` set to:
+Set an environment environment variable to use development settings:
+
+```sh
+export DJANGO_SETTINGS_MODULE="vdv_pkpass.settings_dev"
+```
+
+or change `./manage.py:9` to:
 
 ```py
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "vdv_pkpass.settings_dev")

--- a/main/views/passes.py
+++ b/main/views/passes.py
@@ -60,14 +60,14 @@ def index(request):
                         except RuntimeError as e:
                             image_form.add_error("ticket", f"Error opening PDF: {e}")
                         else:
-                            for page_index in range(len(pdf)):
-                                for pdf_image in pdf.get_page_images(page_index):
-                                    pdf_image = pdf.extract_image(pdf_image[0])
-                                    try:
-                                        ticket_bytes = aztec.decode(pdf_image["image"])
-                                        tickets.append(ticket_bytes)
-                                    except aztec.AztecError:
-                                        continue
+
+                            for page in pdf:
+                                img_bytes = page.get_pixmap(dpi=300).tobytes()
+                                try:
+                                    ticket_bytes = aztec.decode(img_bytes)
+                                    tickets.append(ticket_bytes)
+                                except aztec.AztecError:
+                                    continue
 
                             if not tickets:
                                 image_form.add_error("ticket", f"Failed to find any Aztec codes in the PDF")


### PR DESCRIPTION
heyo!

The app couldn't find any barcodes in my ÖBB PDF, so I fixed that and ended up doing a few other little things. If you want the PDF for testing, DM me, I'd rather not post unused tickets on a public GH issue :)

- **The main one:** PDFs are now rasterized and fed into Barkoder as whole pages instead of extracting individual images (ÖBB PDFs have the codes as vector paths, not images, so the previous approach didn't work)
- Made the whole thing run even if Google and Apple signing creds aren't provided (mainly for local development)
  - this of course means the pkpass file is unsigned, but most Android apps for passes don't really mind (tested PassAndroid, KItinerary, GWallet)
- Added the Barkoder build dir to .dockerignore so the Docker build doesn't fail if you already have some files in there locally
- Tweaked development environment instructions in the README a bit so the commands are more copy-pastable (like not being tied to the location of your venv)

**EDIT:** just saw the other PR, I'll get rid of the Google creds commit and force push