### PR TITLE
Add RCT2 parsing results to ticket view

### DIFF
--- a/main/templates/main/uic/ticket_details.html
+++ b/main/templates/main/uic/ticket_details.html
@@ -273,96 +273,96 @@
         <h2 class="govuk-heading-m">Details parsed from paper ticket</h2>
         <dl class="govuk-summary-list">
             {% if parsed_layout.operator_rics %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Operator RICS</dt>
-                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.operator_rics }}</code></dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Operator RICS</dt>
+                    <dd class="govuk-summary-list__value"><code>{{ parsed_layout.operator_rics }}</code></dd>
+                </div>
             {% endif %}
             {% if parsed_layout.trips %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Trips</dt>
-                <dd class="govuk-summary-list__value">
-                    {% for trip in parsed_layout.trips %}
-                        <div class="govuk-summary-card">
-                            <div class="govuk-summary-card__title-wrapper">
-                                <h2 class="govuk-summary-card__title">
-                                    Trip #{{ forloop.counter }}
-                                </h2>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Trips</dt>
+                    <dd class="govuk-summary-list__value">
+                        {% for trip in parsed_layout.trips %}
+                            <div class="govuk-summary-card">
+                                <div class="govuk-summary-card__title-wrapper">
+                                    <h2 class="govuk-summary-card__title">
+                                        Trip #{{ forloop.counter }}
+                                    </h2>
+                                </div>
+                                <div class="govuk-summary-card__content">
+                                    {% include "main/uic/trip_part.html" with trip=trip %}
+                                </div>
                             </div>
-                            <div class="govuk-summary-card__content">
-                                {% include "main/uic/trip_part.html" with trip=trip %}
-                            </div>
-                        </div>
-                    {% endfor %}
-                </dd>
-            </div>
+                        {% endfor %}
+                    </dd>
+                </div>
             {% endif %}
             {% if parsed_layout.document_type %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Document type</dt>
-                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.document_type }}</code></dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Document type</dt>
+                    <dd class="govuk-summary-list__value"><code>{{ parsed_layout.document_type }}</code></dd>
+                </div>
             {% endif %}
             {% if parsed_layout.traveller %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Traveller</dt>
-                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.traveller }}</code></dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Traveller</dt>
+                    <dd class="govuk-summary-list__value"><code>{{ parsed_layout.traveller }}</code></dd>
+                </div>
             {% endif %}
             {% if parsed_layout.price_data %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Price</dt>
-                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.price_data }}</code></dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Price</dt>
+                    <dd class="govuk-summary-list__value"><code>{{ parsed_layout.price_data }}</code></dd>
+                </div>
             {% endif %}
             {% if parsed_layout.train_data %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Train data</dt>
-                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.train_data }}</code></dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Train data</dt>
+                    <dd class="govuk-summary-list__value"><code>{{ parsed_layout.train_data }}</code></dd>
+                </div>
             {% endif %}
             {% if parsed_layout.conditions %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Conditions</dt>
-                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.conditions }}</code></dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Conditions</dt>
+                    <dd class="govuk-summary-list__value"><code>{{ parsed_layout.conditions }}</code></dd>
+                </div>
             {% endif %}
             {% if parsed_layout.extra %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Extra data</dt>
-                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.extra }}</code></dd>
-            </div>
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Extra data</dt>
+                    <dd class="govuk-summary-list__value"><code>{{ parsed_layout.extra }}</code></dd>
+                </div>
             {% endif %}
             {% if parsed_layout.valid_region %}
-            <div class="govuk-summary-list__row">
-                <dt class="govuk-summary-list__key">Valid region</dt>
-                <dd class="govuk-summary-list__value">
-                    {{ parsed_layout.valid_region }}
-                    {% with graph=parsed_layout.valid_region|via_as_graphviz %}
-                        {% if graph %}
-                            <div id="{{ graph.0 }}" class="route-graph"></div>
-                            <script>
-                                window.addEventListener('load', function () {
-                                    const graph = `{{ graph.1|safe }}`;
-                                    Viz.instance().then(function (viz) {
-                                        const svg = viz.renderSVGElement(graph, {
-                                            graphAttributes: {
-                                                fontname: "GDS Transport",
-                                                fontsize: 12,
-                                            },
-                                            nodeAttributes: {
-                                                fontname: "GDS Transport",
-                                                fontsize: 12,
-                                            }
+                <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Valid region</dt>
+                    <dd class="govuk-summary-list__value">
+                        {{ parsed_layout.valid_region }}
+                        {% with graph=parsed_layout.valid_region|via_as_graphviz %}
+                            {% if graph %}
+                                <div id="{{ graph.0 }}" class="route-graph"></div>
+                                <script>
+                                    window.addEventListener('load', function () {
+                                        const graph = `{{ graph.1|safe }}`;
+                                        Viz.instance().then(function (viz) {
+                                            const svg = viz.renderSVGElement(graph, {
+                                                graphAttributes: {
+                                                    fontname: "GDS Transport",
+                                                    fontsize: 12,
+                                                },
+                                                nodeAttributes: {
+                                                    fontname: "GDS Transport",
+                                                    fontsize: 12,
+                                                }
+                                            });
+                                            document.getElementById('{{ graph.0 }}').appendChild(svg);
                                         });
-                                        document.getElementById('{{ graph.0 }}').appendChild(svg);
                                     });
-                                });
-                            </script>
-                        {% endif %}
-                    {% endwith %}
-                </dd>
-            </div>
+                                </script>
+                            {% endif %}
+                        {% endwith %}
+                    </dd>
+                </div>
             {% endif %}
         </dl>
     {% endif %}

--- a/main/templates/main/uic/ticket_details.html
+++ b/main/templates/main/uic/ticket_details.html
@@ -269,6 +269,104 @@
         {% include "main/uic/dcd.html" with dcd=ticket.dosipas_dcd %}
     {% endif %}
 
+    {% if parsed_layout %}
+        <h2 class="govuk-heading-m">Details parsed from paper ticket</h2>
+        <dl class="govuk-summary-list">
+            {% if parsed_layout.operator_rics %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Operator RICS</dt>
+                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.operator_rics }}</code></dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.trips %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Trips</dt>
+                <dd class="govuk-summary-list__value">
+                    {% for trip in parsed_layout.trips %}
+                        <div class="govuk-summary-card">
+                            <div class="govuk-summary-card__title-wrapper">
+                                <h2 class="govuk-summary-card__title">
+                                    Trip #{{ forloop.counter }}
+                                </h2>
+                            </div>
+                            <div class="govuk-summary-card__content">
+                                {% include "main/uic/trip_part.html" with trip=trip %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.document_type %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Document type</dt>
+                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.document_type }}</code></dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.traveller %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Traveller</dt>
+                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.traveller }}</code></dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.price_data %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Price</dt>
+                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.price_data }}</code></dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.train_data %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Train data</dt>
+                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.train_data }}</code></dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.conditions %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Conditions</dt>
+                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.conditions }}</code></dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.extra %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Extra data</dt>
+                <dd class="govuk-summary-list__value"><code>{{ parsed_layout.extra }}</code></dd>
+            </div>
+            {% endif %}
+            {% if parsed_layout.valid_region %}
+            <div class="govuk-summary-list__row">
+                <dt class="govuk-summary-list__key">Valid region</dt>
+                <dd class="govuk-summary-list__value">
+                    {{ parsed_layout.valid_region }}
+                    {% with graph=parsed_layout.valid_region|via_as_graphviz %}
+                        {% if graph %}
+                            <div id="{{ graph.0 }}" class="route-graph"></div>
+                            <script>
+                                window.addEventListener('load', function () {
+                                    const graph = `{{ graph.1|safe }}`;
+                                    Viz.instance().then(function (viz) {
+                                        const svg = viz.renderSVGElement(graph, {
+                                            graphAttributes: {
+                                                fontname: "GDS Transport",
+                                                fontsize: 12,
+                                            },
+                                            nodeAttributes: {
+                                                fontname: "GDS Transport",
+                                                fontsize: 12,
+                                            }
+                                        });
+                                        document.getElementById('{{ graph.0 }}').appendChild(svg);
+                                    });
+                                });
+                            </script>
+                        {% endif %}
+                    {% endwith %}
+                </dd>
+            </div>
+            {% endif %}
+        </dl>
+    {% endif %}
+
     {% if ticket.layout %}
         {% include 'main/uic/paper.html' with layout=ticket.layout %}
     {% endif %}

--- a/main/templates/main/uic/trip_part.html
+++ b/main/templates/main/uic/trip_part.html
@@ -42,9 +42,9 @@
         </div>
     {% endif %}
     {% if trip.arrival_station %}
-    <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Arrival station</dt>
-        <dd class="govuk-summary-list__value"><code>{{ trip.arrival_station }}</code></dd>
-    </div>
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Arrival station</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.arrival_station }}</code></dd>
+        </div>
     {% endif %}
 </dl>

--- a/main/templates/main/uic/trip_part.html
+++ b/main/templates/main/uic/trip_part.html
@@ -1,0 +1,50 @@
+<dl class="govuk-summary-list">
+    {% if trip.departure %}
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Departure</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.departure }}</code></dd>
+        </div>
+    {% endif %}
+    {% if trip.departure_date %}
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Departure date</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.departure_date }}</code></dd>
+        </div>
+    {% endif %}
+    {% if trip.departure_time %}
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Departure time</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.departure_time }}</code></dd>
+        </div>
+    {% endif %}
+    {% if trip.arrival %}
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Arrival</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.arrival }}</code></dd>
+        </div>
+    {% endif %}
+    {% if trip.arrival_date %}
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Arrival date</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.arrival_date }}</code></dd>
+        </div>
+    {% endif %}
+    {% if trip.arrival_time %}
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Arrival time</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.arrival_time }}</code></dd>
+        </div>
+    {% endif %}
+    {% if trip.departure_station %}
+        <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Departure station</dt>
+            <dd class="govuk-summary-list__value"><code>{{ trip.departure_station }}</code></dd>
+        </div>
+    {% endif %}
+    {% if trip.arrival_station %}
+    <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Arrival station</dt>
+        <dd class="govuk-summary-list__value"><code>{{ trip.arrival_station }}</code></dd>
+    </div>
+    {% endif %}
+</dl>

--- a/main/templatetags/rics.py
+++ b/main/templatetags/rics.py
@@ -168,7 +168,7 @@ def nuts_region_name(value):
 
 @register.filter(name="via_as_graphviz")
 def via_as_graphviz(value):
-    if value.lower().startswith("via:"):
+    if value.lower().startswith("via:") or value.lower().startswith("via "):
         via = uic.parse_via.parse_via(value)
         return uuid.uuid4(), via.to_graph()
 

--- a/main/uic/rct2_parse.py
+++ b/main/uic/rct2_parse.py
@@ -120,12 +120,9 @@ class RCT2Parser:
         valid_region =        self.read_area(top=8,  left=0,  width=20, height=1)
         price_data =          self.read_area(top=13, left=52, width=20, height=2)
         train_data =          self.read_area(top=8,  left=0,  width=72, height=4)
+        valid_region =        self.read_area(top=8,  left=0,  width=72, height=1)
         conditions_data =     self.read_area(top=12, left=0,  width=50, height=3)
         operator_rics =       self.read_area(top=2,  left=5,  width=4,  height=1).lstrip(" 0").rstrip(" ")
-
-        valid_region = None
-        if train_data[0:3] == "VIA":
-            valid_region = train_data
 
         try:
             operator_rics = int(operator_rics, 10)

--- a/main/uic/rct2_parse.py
+++ b/main/uic/rct2_parse.py
@@ -130,6 +130,10 @@ class RCT2Parser:
             operator_rics = 0
         extra_data =          self.read_area(top=3,  left=0,  width=52, height=1)
 
+        if operator_rics == 1088:
+            # SNCB uses square brackets in the via-string where chevrons should be used
+            valid_region = valid_region.replace("[", "<").replace("]", ">")
+
         return ParsedRCT2(
             operator_rics=operator_rics,
             travel_class=travel_class,

--- a/main/uic/rct2_parse.py
+++ b/main/uic/rct2_parse.py
@@ -130,8 +130,8 @@ class RCT2Parser:
             operator_rics = 0
         extra_data =          self.read_area(top=3,  left=0,  width=52, height=1)
 
-        if operator_rics == 1088:
-            # SNCB uses square brackets in the via-string where chevrons should be used
+        if operator_rics in (1088, 1184):
+            # benerail (NSI and NMBS International) uses square brackets in the via-string where chevrons should be used
             valid_region = valid_region.replace("[", "<").replace("]", ">")
 
         return ParsedRCT2(

--- a/main/uic/rct2_parse.py
+++ b/main/uic/rct2_parse.py
@@ -117,7 +117,6 @@ class RCT2Parser:
 
         document_data =       self.read_area(top=0,  left=18, width=34, height=3)
         traveller_data =      self.read_area(top=0,  left=52, width=20, height=3)
-        valid_region =        self.read_area(top=8,  left=0,  width=20, height=1)
         price_data =          self.read_area(top=13, left=52, width=20, height=2)
         train_data =          self.read_area(top=8,  left=0,  width=72, height=4)
         valid_region =        self.read_area(top=8,  left=0,  width=72, height=1)

--- a/main/uic/rct2_parse.py
+++ b/main/uic/rct2_parse.py
@@ -28,6 +28,7 @@ class ParsedRCT2:
     train_data: str
     conditions: str
     extra: str
+    valid_region: str
 
 
 class RCT2Parser:
@@ -116,10 +117,16 @@ class RCT2Parser:
 
         document_data =       self.read_area(top=0,  left=18, width=34, height=3)
         traveller_data =      self.read_area(top=0,  left=52, width=20, height=3)
+        valid_region =        self.read_area(top=8,  left=0,  width=20, height=1)
         price_data =          self.read_area(top=13, left=52, width=20, height=2)
         train_data =          self.read_area(top=8,  left=0,  width=72, height=4)
         conditions_data =     self.read_area(top=12, left=0,  width=50, height=3)
         operator_rics =       self.read_area(top=2,  left=5,  width=4,  height=1).lstrip(" 0").rstrip(" ")
+
+        valid_region = None
+        if train_data[0:3] == "VIA":
+            valid_region = train_data
+
         try:
             operator_rics = int(operator_rics, 10)
         except ValueError:
@@ -136,4 +143,5 @@ class RCT2Parser:
             train_data=train_data,
             conditions=conditions_data,
             extra=extra_data,
+            valid_region = valid_region,
         )

--- a/main/views/passes.py
+++ b/main/views/passes.py
@@ -141,6 +141,14 @@ def view_ticket(request, pk):
     has_saarvv = ticket_obj.account and ticket_obj.account.is_saarvv_authenticated()
     has_db_abo = (ticket_obj.account and ticket_obj.account.is_db_authenticated()) or ticket_obj.db_subscription
 
+    parsed_layout = None
+    if isinstance(active_instance, models.UICTicketInstance):
+        ticket_data: ticket.UICTicket = active_instance.as_ticket()
+        if ticket_data.layout and ticket_data.layout.standard in ("RCT2", "RTC2"):
+            parser = uic.rct2_parse.RCT2Parser()
+            parser.read(ticket_data.layout)
+            parsed_layout = parser.parse(active_instance.distributor_rics)
+
     photo_upload_forms = {}
     if rsp_obj := ticket_obj.rsp_instances.first():
         td = rsp_obj.as_ticket()  # type: ticket.RSPTicket
@@ -184,6 +192,7 @@ def view_ticket(request, pk):
         "has_saarvv": has_saarvv,
         "is_db_abo": is_db_abo,
         "has_db_abo": has_db_abo,
+        "parsed_layout": parsed_layout,
     })
 
 


### PR DESCRIPTION
This PR adds the results of parsing the RCT2 layout (if applicable) to the ticket view.
Primary purpose would be to be able to see the 'decoded' valid region (the 'VIA xxxxx' string).

![image](https://github.com/user-attachments/assets/cd7ecd71-0ec1-4193-a78f-d081e2637116)
