### PR TITLE
Wrap attempt to parse datetime out of rct2 layout in try-except block

### DIFF
--- a/main/uic/rct2_parse.py
+++ b/main/uic/rct2_parse.py
@@ -80,14 +80,20 @@ class RCT2Parser:
                 arrival =   self.read_area(top=line, left=52, width=10, height=1)
 
                 if departure:
-                    departure_dt = datetime.datetime.strptime(departure, "%d%m%y%H%M")
+                    try:
+                        departure_dt = datetime.datetime.strptime(departure, "%d%m%y%H%M")
+                    except ValueError:
+                        pass
                     departure_date = f"{departure[0:2]}.{departure[2:4]}.{departure[4:6]}"
                     departure_time = f"{departure[6:8]}:{departure[8:10]}"
                 else:
                     departure_date = ""
                     departure_time = ""
                 if arrival:
-                    arrival_dt = datetime.datetime.strptime(arrival, "%d%m%y%H%M")
+                    try:
+                        arrival_dt = datetime.datetime.strptime(arrival, "%d%m%y%H%M")
+                    except ValueError:
+                        pass
                     arrival_date = f"{arrival[0:2]}.{arrival[2:4]}.{arrival[4:6]}"
                     arrival_time = f"{arrival[6:8]}:{arrival[8:10]}"
                 else:


### PR DESCRIPTION
I ran across a NSI reservation from a while ago (@TheEnbyperor see Threema). Attempting to parse it fails, as there are two calls to `strptime` in main/uic/rct2_parse.py (to define `departure_dt` and `arrival_dt`) that fail as the string to parse does not match the parsing definition.

This PR wraps those two calls in a try-except block. Nothing is done in the `except:` section as both variables are already set to None.

I'm not entirely sure if I've ever seen a ticket that has something corresponding to `%d%m%y%H%M` but that's another question IMO

