### PR TITLE
Turn off iOS Safari phone number detection

### DIFF
--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="format-detection" content="telephone=no">
 
     <link href='{% static "govuk/govuk-frontend-5.6.0.min.css" %}' rel="stylesheet">
     <link href='{% static "main/style.css" %}' rel="stylesheet">


### PR DESCRIPTION
Without this, iOS Safari tries to convert reservation reference numbers
on VR tickets into phone number links.
