### PR TITLE
Add product code for new-style Youth Holidays tickets

### DIFF
--- a/main/uic/data/sncb_products.json
+++ b/main/uic/data/sncb_products.json
@@ -13,6 +13,8 @@
   "DP3": "Local Multi",
   "DP5": "Youth Multi Under 26",
   "DP7": "Youth Holidays 1 Week",
+  "DW1": "Youth Holidays 1 Week",
+  "DWA": "Validated Youth Holidays Ticket",
   "DW3": "Off-peak Unlimited",
   "65P": "Senior Ticket 65+",
   "0040002614": "BruPass",


### PR DESCRIPTION
Bought one just now and they need validation from the SNCB app now. DW1 is for the pass proper as displayed in the SNCB app (don't think they issue barcodes with that ofc but can't hurt), DWA is for the validated ticket

(the tickets proper otherwise function as normal NRT tickets)
![image](https://github.com/user-attachments/assets/c57a7beb-5a57-4470-bcc7-e9d68e425a20)
