### PR TITLE
fix: update desktop database after installation

### DIFF
--- a/main/static/main/zuegli-login-linux.sh
+++ b/main/static/main/zuegli-login-linux.sh
@@ -46,4 +46,6 @@ xdg-mime default zuegli-hook.desktop x-scheme-handler/stoag
 xdg-mime default zuegli-hook.desktop x-scheme-handler/swk
 xdg-mime default zuegli-hook.desktop x-scheme-handler/ver
 
+sudo update-desktop-database ~/.local/share/applications
+
 echo "Install complete ✨"


### PR DESCRIPTION
On ubuntu sometimes the xdg-portal doesn't get the updated handler by default, therefore a  reload must be done manually. (See this issue: https://askubuntu.com/questions/1440860/browsers-cant-open-custom-uri-x-scheme-handler-via-xdg-but-it-works-well-from)

This PR adds the reload after hook installation.