### PR TITLE
Add new post-Train+ SNCB product codes

### DIFF
--- a/main/uic/data/sncb_products.json
+++ b/main/uic/data/sncb_products.json
@@ -29,5 +29,6 @@
   "Q21": "Weekend Ticket - Adult",
   "Q22": "Ticket - Anytime - Adult - Train+",
   "Q23": "Ticket - Off-peak - Adult - Train+",
+  "Q42": "Ticket - Anytime - Senior - Train+",
   "Q50": "Ticket - Anytime - Preferential Reimbursement"
 }

--- a/main/uic/data/sncb_products.json
+++ b/main/uic/data/sncb_products.json
@@ -25,10 +25,10 @@
   "I47": "Summer Deal",
   "D_O2_AS_YOUTH_AC": "Ticket - Off-peak - Youth - Train+",
   "D_O1_AS_AC": "Ticket - Off-peak - Adult - Train+",
-  "Q20": "Ticket - Anytime - Adult",
-  "Q21": "Weekend Ticket - Adult",
-  "Q22": "Ticket - Anytime - Adult - Train+",
-  "Q23": "Ticket - Off-peak - Adult - Train+",
-  "Q42": "Ticket - Anytime - Senior - Train+",
-  "Q50": "Ticket - Anytime - Preferential Reimbursement"
+  "100Q20": "Ticket - Anytime - Adult",
+  "100Q21": "Weekend Ticket - Adult",
+  "100Q22": "Ticket - Anytime - Adult - Train+",
+  "100Q23": "Ticket - Off-peak - Adult - Train+",
+  "100Q42": "Ticket - Anytime - Senior - Train+",
+  "100Q50": "Ticket - Anytime - Preferential Reimbursement"
 }

--- a/main/uic/data/sncb_products.json
+++ b/main/uic/data/sncb_products.json
@@ -23,7 +23,7 @@
   "VAC": "Vaccination Ticket",
   "LU1": "Standard - Luxembourg",
   "I47": "Summer Deal",
-  "D_O2_AS_YOUTH_AC": "Ticket - Off-peak - Youth T- rain+",
+  "D_O2_AS_YOUTH_AC": "Ticket - Off-peak - Youth - Train+",
   "D_O1_AS_AC": "Ticket - Off-peak - Adult - Train+",
   "Q20": "Ticket - Anytime - Adult",
   "Q21": "Weekend Ticket - Adult",

--- a/main/uic/data/sncb_products.json
+++ b/main/uic/data/sncb_products.json
@@ -23,5 +23,11 @@
   "VAC": "Vaccination Ticket",
   "LU1": "Standard - Luxembourg",
   "I47": "Summer Deal",
-  "D_O2_AS_YOUTH_AC": "Ticket Off-peak Youth Train+"
+  "D_O2_AS_YOUTH_AC": "Ticket - Off-peak - Youth T- rain+",
+  "D_O1_AS_AC": "Ticket - Off-peak - Adult - Train+",
+  "Q20": "Ticket - Anytime - Adult",
+  "Q21": "Weekend Ticket - Adult",
+  "Q22": "Ticket - Anytime - Adult - Train+",
+  "Q23": "Ticket - Off-peak - Adult - Train+",
+  "Q50": "Ticket - Anytime - Preferential Reimbursement"
 }

--- a/main/uic/data/sncb_products.json
+++ b/main/uic/data/sncb_products.json
@@ -29,6 +29,7 @@
   "100Q21": "Weekend Ticket - Adult",
   "100Q22": "Ticket - Anytime - Adult - Train+",
   "100Q23": "Ticket - Off-peak - Adult - Train+",
+  "100Q24": "Weekend Ticket - Adult - Train+",
   "100Q42": "Ticket - Anytime - Senior - Train+",
   "100Q50": "Ticket - Anytime - Preferential Reimbursement"
 }


### PR DESCRIPTION
This adds the new SNCB prouct codes i have been able to verify in the new Train+ ticket scheme.
The Q codes are prefixed `100` in the SSB but not on the actual product name . Should I prefix them here?