### PR TITLE
Add VBB 4-Fahrten-Karte product ID

### DIFF
--- a/main/vdv/data/products/productids_custom.json
+++ b/main/vdv/data/products/productids_custom.json
@@ -6,6 +6,9 @@
     "key": "6100_2128",
     "text": "Fahrrad Monatskarte"
   }, {
+    "key": "6100_4000",
+    "text": "4-Fahrten-Karte"
+  }, {
     "key": "6100_4004",
     "text": "Einzelfahrausweis"
   }, {


### PR DESCRIPTION
See SZOBVFYR, matches against price seen [here](https://www.vbb.de/tickets/einzelfahrausweise/4-fahrten-karte/#c35878:~:text=Einzelfahrausweis%20Berlin%20ABC-,16%2C80,-11%2C60). I am unsure if this only applies to Berlin 4FK or all VBB ones, yet I also don't want to give the VBB the extra money to check ;)