### PR TITLE
Benerail passenger name on pass

### DIFF
--- a/main/uic/rct2_parse.py
+++ b/main/uic/rct2_parse.py
@@ -141,6 +141,15 @@ class RCT2Parser:
         else:
             passenger_name = None
 
+        # the passenger name area in benerail tickets is formatted like "LASTNAME FIRSTNAME\n01 PASSENGER"
+        # (where PASSENGER can be replaced with the age category of the passenger, i.e. 'JUGENDLICHER')
+        # perhaps also others, update the below tuple if the same logic can be applied there as well
+        if issuing_rics in (1184, 1088):
+            benerail_name_regex = re.search(r'^(.*)\n(\d\d) (.*)$', traveller_data)
+            if benerail_name_regex:
+                passenger_name = benerail_name_regex.group(1)
+
+
         for line in (6, 7):
             departure_dt = None
             arrival_dt = None

--- a/main/views/passes.py
+++ b/main/views/passes.py
@@ -2629,7 +2629,9 @@ def make_pkpass_file(ticket_obj: "models.Ticket", part: typing.Optional[str] = N
                 })
 
             if parsed_layout.passenger_name:
-                if pass_fields["primaryFields"]:
+                if pass_fields["primaryFields"] and parsed_layout.operator_rics not in (1084, 1184):
+                    # passenger name can be on primaryFields if we know the parsing of the RCT2 ticket to be reliable
+                    # (this is the case for at least SNCB internationaal and NSI)
                     pass_fields["auxiliaryFields"].append({
                         "key": "passenger",
                         "label": "passenger-label",


### PR DESCRIPTION
As discussed. Displaying the passengers' name on the pass front is desirable, but often unreliable for passes that don't have flex data. We know the layout of benerail tickets, however, and therefore can reliably parse the passengers' name out and display it on the pass front.

Example for an SNCB international ticket:
<img width="1206" height="779" alt="image" src="https://github.com/user-attachments/assets/6c333767-c94b-4063-812d-be00c8db0756" />
